### PR TITLE
Fix license in NuGet package manifest

### DIFF
--- a/ImGui.Forms/ImGui.Forms.nuspec
+++ b/ImGui.Forms/ImGui.Forms.nuspec
@@ -13,7 +13,7 @@
     <tags>ImGui;Forms;ImGui.NET;GUI</tags>
 
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <license type="expression">GPL-3.0-only</license>
+    <license type="expression">MIT</license>
 
     <repository type="git" url="https://github.com/FanTranslatorsInternational/ImGui.Forms" />
 


### PR DESCRIPTION
According to [#5 (comment)](https://github.com/FanTranslatorsInternational/ImGui.Forms/issues/5#issuecomment-2848682091), project is licensed under the MIT License, but `ImGui.Forms.nuspec` file specifies GPL3 as the license.